### PR TITLE
Rename endpoint

### DIFF
--- a/MosaicResidentInformationApi/V1/Controllers/MosaicController.cs
+++ b/MosaicResidentInformationApi/V1/Controllers/MosaicController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace MosaicResidentInformationApi.V1.Controllers
 {
     [ApiController]
-    [Route("api/v1/contact")]
+    [Route("api/v1/residents")]
     [Produces("application/json")]
     [ApiVersion("1.0")]
     public class MosaicController : BaseController


### PR DESCRIPTION
As per a change in the swagger hub doc: 
https://app.swaggerhub.com/apis/Hackney/mosaic-resident-information-api/1.0