### PR TITLE
Don't run tests that touch the database in parallel

### DIFF
--- a/MosaicResidentInformationApi.Tests/DatabaseTests.cs
+++ b/MosaicResidentInformationApi.Tests/DatabaseTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace MosaicResidentInformationApi.Tests
 {
+    [NonParallelizable]
+    [TestFixture]
     public class DatabaseTests
     {
         protected MosaicContext MosaicContext;

--- a/MosaicResidentInformationApi.Tests/E2ETests.cs
+++ b/MosaicResidentInformationApi.Tests/E2ETests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 
 namespace MosaicResidentInformationApi.Tests
 {
+    [NonParallelizable]
+    [TestFixture]
     public class E2ETests<TStartup> where TStartup : class
     {
         protected HttpClient Client;


### PR DESCRIPTION
I think running them in parallel is causing duplicate key violations when running the tests