### PR TITLE
Create a new database context for each test

### DIFF
--- a/MosaicResidentInformationApi.Tests/DatabaseTests.cs
+++ b/MosaicResidentInformationApi.Tests/DatabaseTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using MosaicResidentInformationApi.V1.Infrastructure;
@@ -13,20 +11,20 @@ namespace MosaicResidentInformationApi.Tests
     {
         protected MosaicContext MosaicContext;
         private IDbContextTransaction _transaction;
+        private DbContextOptionsBuilder _builder;
 
         [OneTimeSetUp]
         public void RunBeforeAnyTests()
         {
-            var builder = new DbContextOptionsBuilder();
-            builder.UseNpgsql(ConnectionString.TestDatabase());
-
-            MosaicContext = new MosaicContext(builder.Options);
-            MosaicContext.Database.EnsureCreated();
+            _builder = new DbContextOptionsBuilder();
+            _builder.UseNpgsql(ConnectionString.TestDatabase());
         }
 
         [SetUp]
         public void SetUp()
         {
+            MosaicContext = new MosaicContext(_builder.Options);
+            MosaicContext.Database.EnsureCreated();
             _transaction = MosaicContext.Database.BeginTransaction();
         }
 

--- a/MosaicResidentInformationApi.Tests/E2ETests.cs
+++ b/MosaicResidentInformationApi.Tests/E2ETests.cs
@@ -17,6 +17,7 @@ namespace MosaicResidentInformationApi.Tests
         private MockWebApplicationFactory<TStartup> _factory;
         private NpgsqlConnection _connection;
         private IDbContextTransaction _transaction;
+        private DbContextOptionsBuilder _builder;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -27,10 +28,8 @@ namespace MosaicResidentInformationApi.Tests
             npgsqlCommand.CommandText = "SET deadlock_timeout TO 30";
             npgsqlCommand.ExecuteNonQuery();
 
-            var builder = new DbContextOptionsBuilder();
-            builder.UseNpgsql(_connection);
-            MosaicContext = new MosaicContext(builder.Options);
-            MosaicContext.Database.EnsureCreated();
+            _builder = new DbContextOptionsBuilder();
+            _builder.UseNpgsql(_connection);
         }
 
         [SetUp]
@@ -38,7 +37,8 @@ namespace MosaicResidentInformationApi.Tests
         {
             _factory = new MockWebApplicationFactory<TStartup>(_connection);
             Client = _factory.CreateClient();
-
+            MosaicContext = new MosaicContext(_builder.Options);
+            MosaicContext.Database.EnsureCreated();
             _transaction = MosaicContext.Database.BeginTransaction();
         }
 


### PR DESCRIPTION
The database context tracks all changes to the database. If you try and add something that has the same key as an entity being it tracked it will throw an error.

As the same context was being used for all tests it was storing all the entities added in each test and throwing errors when two entities with the same key happened to be created. 

Using a new context for each test means that the tests will not be affected by entities added in other tests.