### PR TITLE
Let primary key for database entities be autogenerated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,18 @@ shell:
 test:
 	docker-compose build mosaic-resident-information-api-test && docker-compose up mosaic-resident-information-api-test
 
+.PHONY: start-test-db
+start-test-db:
+	docker-compose up -d test-database
+
+.PHONY: restart-test-db
+restart-test-db:
+	-container_id=$$(eval docker ps -aqf "name=test-database") \
+	echo $$container_id \
+	-docker kill $$container_id \
+	-docker rm $$container_id
+	docker-compose up -d test-database
+
 .PHONY: lint
 lint:
 	-dotnet tool install -g dotnet-format

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ start-test-db:
 .PHONY: restart-test-db
 restart-test-db:
 	-container_id=$$(eval docker ps -aqf "name=test-database") \
-	echo $$container_id \
 	-docker kill $$container_id \
 	-docker rm $$container_id
 	docker-compose up -d test-database

--- a/MosaicResidentInformationApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/MosaicResidentInformationApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -11,14 +11,12 @@ namespace MosaicResidentInformationApi.Tests.V1.E2ETests
     {
         public static ResidentInformation AddPersonWithRelatesEntitiesToDb(MosaicContext context, int? id = null, string firstname = null, string lastname = null, string postcode = null, string addressLines = null)
         {
-            var person = TestHelper.CreateDatabasePersonEntity(firstname, lastname);
-            if (id != null) person.Id = (int) id;
-
-            var address = TestHelper.CreateDatabaseAddressForPersonId(person.Id, address: addressLines, postcode: postcode);
-            var phone = TestHelper.CreateDatabaseTelephoneNumberForPersonId(person.Id);
-
-            context.Persons.Add(person);
+            var person = TestHelper.CreateDatabasePersonEntity(firstname, lastname, id);
+            var addedPerson = context.Persons.Add(person);
             context.SaveChanges();
+
+            var address = TestHelper.CreateDatabaseAddressForPersonId(addedPerson.Entity.Id, address: addressLines, postcode: postcode);
+            var phone = TestHelper.CreateDatabaseTelephoneNumberForPersonId(addedPerson.Entity.Id);
 
             context.Addresses.Add(address);
             context.TelephoneNumbers.Add(phone);

--- a/MosaicResidentInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/MosaicResidentInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -1,24 +1,26 @@
 using AutoFixture;
-using Bogus;
 using MosaicResidentInformationApi.V1.Boundary.Responses;
 using MosaicResidentInformationApi.V1.Infrastructure;
 using Address = MosaicResidentInformationApi.V1.Infrastructure.Address;
 using Person = MosaicResidentInformationApi.V1.Infrastructure.Person;
-using ResidentInformation = MosaicResidentInformationApi.V1.Domain.ResidentInformation;
 using System;
 
 namespace MosaicResidentInformationApi.Tests.V1.Helper
 {
     public static class TestHelper
     {
-        public static Person CreateDatabasePersonEntity(string firstname = null, string lastname = null)
+        public static Person CreateDatabasePersonEntity(string firstname = null, string lastname = null, int? id = null)
         {
             var faker = new Fixture();
-            var fp = faker.Create<Person>();
+            var fp = faker.Build<Person>()
+                .Without(p => p.Id)
+                .Create();
             fp.DateOfBirth = new DateTime
                 (fp.DateOfBirth.Year, fp.DateOfBirth.Month, fp.DateOfBirth.Day);
             fp.FirstName = firstname ?? fp.FirstName;
             fp.LastName = lastname ?? fp.LastName;
+            if (id != null) fp.Id = (int) id;
+
             return fp;
         }
 
@@ -28,6 +30,7 @@ namespace MosaicResidentInformationApi.Tests.V1.Helper
 
             var fa = faker.Build<Address>()
                 .With(add => add.PersonId, personId)
+                .Without(add => add.PersonAddressId)
                 .Without(add => add.Person)
                 .Create();
 
@@ -43,6 +46,7 @@ namespace MosaicResidentInformationApi.Tests.V1.Helper
             return faker.Build<TelephoneNumber>()
                 .With(tel => tel.PersonId, personId)
                 .With(tel => tel.Type, PhoneType.Mobile.ToString)
+                .Without(tel => tel.Id)
                 .Without(tel => tel.Person)
                 .Create();
         }


### PR DESCRIPTION
- This is to prevent multiple entities with the same key being added within a test and hence producing an error
- This also adds a make command to start and restart the test db 