### PR TITLE
VPC prod config for serverless + remove cloudwatch log group name in tf

### DIFF
--- a/MosaicResidentInformationApi/serverless.yml
+++ b/MosaicResidentInformationApi/serverless.yml
@@ -85,3 +85,9 @@ custom:
       subnetIds:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656
+    production:
+      securityGroupIds:
+        - sg-0e2398788c29e09ca
+      subnetId:
+        - subnet-01d3657f97a243261
+        - subnet-0b7b8fea07efabf34

--- a/terraform/production/task_settings.json
+++ b/terraform/production/task_settings.json
@@ -50,7 +50,7 @@
                 "Severity": "LOGGER_SEVERITY_DEFAULT"
             }
         ],
-        "CloudWatchLogGroup": "/aws/dms/mosaic-api/production/gateway-replication",
+        "CloudWatchLogGroup": null,
         "CloudWatchLogStream": null
     },
     "ControlTablesSettings": {


### PR DESCRIPTION
- You can't name the cloud watch log group upon create, I'm assuming it creates its own log group.