### PR TITLE
Add API keys to serverless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./MosaicResidentInformationApi/
-            sls deploy --stage <<parameters.stage>>
+            sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:
   check-code-formatting:

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ bin/
 tmp/
 .vs/
 /MosaicResidentInformationApi.Tests/Properties/launchSettings.json
+.serverless/

--- a/MosaicResidentInformationApi/serverless.yml
+++ b/MosaicResidentInformationApi/serverless.yml
@@ -5,6 +5,14 @@ provider:
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
+  apiKeys:
+    - usage-plan-${self:service}-${opt:stage}:
+      - api-key-${self:service}-${opt:stage}
+  usagePlan:
+    - usage-plan-${self:service}-${opt:stage}:
+        throttle:
+          burstLimit: 200
+          rateLimit: 100
 
 package:
   artifact: ./bin/release/netcoreapp3.1/mosaic-resident-information-api.zip
@@ -20,6 +28,7 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
+          private: true
 resources:
   Resources:
     lambdaExecutionRole:


### PR DESCRIPTION
- Add API keys to serverless yml
- Add --conceal to deployment command to ensure API keys are not shown in output during deployment in pipeline