### PR TITLE
Add composite primary key to telephone table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ tmp/
 .vs/
 /MosaicResidentInformationApi.Tests/Properties/launchSettings.json
 .serverless/
+
+.fake
+.ionide
+.vscode

--- a/MosaicResidentInformationApi/V1/Infrastructure/MosaicContext.cs
+++ b/MosaicResidentInformationApi/V1/Infrastructure/MosaicContext.cs
@@ -10,5 +10,16 @@ namespace MosaicResidentInformationApi.V1.Infrastructure
         public DbSet<Person> Persons { get; set; }
         public DbSet<TelephoneNumber> TelephoneNumbers { get; set; }
         public DbSet<Address> Addresses { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // composite primary key for TelephoneNumber table
+            modelBuilder.Entity<TelephoneNumber>()
+                .HasKey(telephoneNumber => new
+                {
+                    telephoneNumber.Id,
+                    telephoneNumber.PersonId
+                });
+        }
     }
 }

--- a/MosaicResidentInformationApi/V1/Infrastructure/TelephoneNumber.cs
+++ b/MosaicResidentInformationApi/V1/Infrastructure/TelephoneNumber.cs
@@ -8,7 +8,6 @@ namespace MosaicResidentInformationApi.V1.Infrastructure
     {
         [Column("telephone_number_id")]
         [MaxLength(9)]
-        [Key]
         public int Id { get; set; }
 
         [Column("telephone_number")]


### PR DESCRIPTION
From looking at the mirror in AWS and what's defined in the schema, the telephone number has a composite primary key made up of `PERSON_ID` and `TELEPHONE_NUMBER_ID`.