### PR TITLE
Add No Tracking Query Behaviour

### DIFF
--- a/MosaicResidentInformationApi/Startup.cs
+++ b/MosaicResidentInformationApi/Startup.cs
@@ -117,7 +117,7 @@ namespace MosaicResidentInformationApi
         {
             var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING");
 
-            services.AddDbContext<MosaicContext>(options => options.UseNpgsql(connectionString));
+            services.AddDbContext<MosaicContext>(options => options.UseNpgsql(connectionString).UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking));
         }
 
         private static void RegisterGateways(IServiceCollection services)


### PR DESCRIPTION
This should make the querying quicker since no change tracking information needs to be set up. We are not currently updating any entities in the mirror DB.

Inspired by this [PR discussion](https://github.com/LBHackney-IT/academy-resident-information-api/pull/35#discussion_r452022229).