### PR TITLE
Add a semicolon to the end of the connection string

### DIFF
--- a/MosaicResidentInformationApi/serverless.yml
+++ b/MosaicResidentInformationApi/serverless.yml
@@ -23,7 +23,7 @@ functions:
     handler: MosaicResidentInformationApi::MosaicResidentInformationApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
     environment:
-      CONNECTION_STRING: Host=${ssm:/mosaic-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/mosaic-api/${self:provider.stage}/postgres-port};Database=mosaic_mirror;Username=${ssm:/mosaic-api/${self:provider.stage}/postgres-username};Password=${ssm:/mosaic-api/${self:provider.stage}/postgres-password}
+      CONNECTION_STRING: Host=${ssm:/mosaic-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/mosaic-api/${self:provider.stage}/postgres-port};Database=mosaic_mirror;Username=${ssm:/mosaic-api/${self:provider.stage}/postgres-username};Password=${ssm:/mosaic-api/${self:provider.stage}/postgres-password};
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
Currently investigating an error that occurs when testing the API
Error: `Microsoft.EntityFrameworkCore.Database.Connection: An error occurred using the connection to database`
There isn't any nested exception with it.

Noticed that the connection string doesn't have a semicolon at the end. Wondering if that might help.