### PR TITLE
Modify DMS to convert table names and columns to lowercase

### DIFF
--- a/terraform/production/selection_rules.json
+++ b/terraform/production/selection_rules.json
@@ -12,9 +12,20 @@
             "filters": []
         },
         {
+          "rule-type": "transformation",
+          "rule-id": "2",
+          "rule-name": "2",
+          "rule-action": "convert-lowercase",
+          "rule-target": "table",
+          "object-locator": {
+            "schema-name": "%",
+            "table-name": "DM_PERSONS"
+          }
+        },
+        {
             "rule-type": "selection",
-            "rule-id": "2",
-            "rule-name": "2",
+            "rule-id": "3",
+            "rule-name": "3",
             "object-locator": {
                 "schema-name": "%",
                 "table-name": "DM_ADDRESSES"
@@ -23,15 +34,49 @@
             "filters": []
         },
         {
+          "rule-type": "transformation",
+          "rule-id": "4",
+          "rule-name": "4",
+          "rule-action": "convert-lowercase",
+          "rule-target": "table",
+          "object-locator": {
+            "schema-name": "%",
+            "table-name": "DM_ADDRESSES"
+          }
+        },
+        {
             "rule-type": "selection",
-            "rule-id": "3",
-            "rule-name": "3",
+            "rule-id": "5",
+            "rule-name": "5",
             "object-locator": {
                 "schema-name": "%",
                 "table-name": "DM_TELEPHONE_NUMBERS"
             },
             "rule-action": "include",
             "filters": []
+        },
+        {
+          "rule-type": "transformation",
+          "rule-id": "6",
+          "rule-name": "6",
+          "rule-action": "convert-lowercase",
+          "rule-target": "table",
+          "object-locator": {
+            "schema-name": "%",
+            "table-name": "DM_TELEPHONE_NUMBERS"
+          }
+        },
+        {
+          "rule-type": "transformation",
+          "rule-id": "7",
+          "rule-name": "7",
+          "rule-action": "convert-lowercase",
+          "rule-target": "column",
+          "object-locator": {
+            "schema-name": "%",
+            "table-name": "%",
+            "column-name": "%"
+          }
         }
     ]
 }


### PR DESCRIPTION
While testing the Mosaic Production API, the logs described the tables as not existing when the gateway makes the query. From investigating the cause, the table names do exist but are in uppercase, e.g. `DM_PERSONS`.

However, entity framework seems to be generating queries targeting the lowercase table name, e.g. `dm_persons`.

After researching and trying different ways to get the right table targeted when querying, it felt simpler to convert the table names & columns from uppercase to lowercase when we perform DMS.

This PR adds transformation rules to the DMS for the Mosaic Mirror to have all the columns and table names in lower case.