### PR TITLE
Add MosaicGateway#InsertResident and AddResident use case

### DIFF
--- a/MosaicResidentInformationApi.Tests/V1/Gateways/MosaicGatewayTests.cs
+++ b/MosaicResidentInformationApi.Tests/V1/Gateways/MosaicGatewayTests.cs
@@ -450,6 +450,25 @@ namespace MosaicResidentInformationApi.Tests.V1.Gateways
                 .Should().BeEquivalentTo(new List<string> { "3", "4", "5" });
         }
 
+        [Test]
+        public void InsertResidentReturnsResidentInformation()
+        {
+            var residentInformation = _classUnderTest.InsertResident(firstName: "Adora", lastName: "Grayskull");
+
+            residentInformation.MosaicId.Should().NotBeNull();
+            residentInformation.FirstName.Should().Be("Adora");
+            residentInformation.LastName.Should().Be("Grayskull");
+        }
+
+        [Test]
+        public void InsertResidentCreatesAPersonRecord()
+        {
+            var residentInformation = _classUnderTest.InsertResident(firstName: "Adora", lastName: "Grayskull");
+
+            MosaicContext.Persons.First().FirstName.Should().Be("Adora");
+            MosaicContext.Persons.First().LastName.Should().Be("Grayskull");
+        }
+
 
         private Person AddPersonRecordToDatabase(string firstname = null, string lastname = null, int? id = null)
         {

--- a/MosaicResidentInformationApi.Tests/V1/UseCase/AddResidentUseCaseTests.cs
+++ b/MosaicResidentInformationApi.Tests/V1/UseCase/AddResidentUseCaseTests.cs
@@ -1,0 +1,49 @@
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using MosaicResidentInformationApi.V1.Boundary.Requests;
+using MosaicResidentInformationApi.V1.Gateways;
+using MosaicResidentInformationApi.V1.UseCase;
+using NUnit.Framework;
+using ResidentInformation = MosaicResidentInformationApi.V1.Domain.ResidentInformation;
+
+namespace MosaicResidentInformationApi.Tests.V1.UseCase
+{
+    [TestFixture]
+    public class AddResidentUseCaseTests
+    {
+        private Mock<IMosaicGateway> _mockMosaicGateway;
+        private AddResidentUseCase _classUnderTest;
+        private readonly Fixture _fixture = new Fixture();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockMosaicGateway = new Mock<IMosaicGateway>();
+
+            _classUnderTest = new AddResidentUseCase(_mockMosaicGateway.Object);
+        }
+
+        [Test]
+        public void ReturnsResidentInformation()
+        {
+            var residentInformation = _fixture.Build<ResidentInformation>()
+                .With(r => r.FirstName, "Adora")
+                .With(r => r.LastName, "Grayskull")
+                .Create();
+            var addResidentRequest = new AddResidentRequest()
+            {
+                FirstName = "Adora",
+                LastName = "Grayskull",
+            };
+            _mockMosaicGateway.Setup(x =>
+                    x.InsertResident("Adora", "Grayskull"))
+                .Returns(residentInformation);
+
+            var response = _classUnderTest.Execute(addResidentRequest);
+
+            response.FirstName.Should().Be("Adora");
+            response.LastName.Should().Be("Grayskull");
+        }
+    }
+}

--- a/MosaicResidentInformationApi/V1/Boundary/Requests/AddResidentRequest.cs
+++ b/MosaicResidentInformationApi/V1/Boundary/Requests/AddResidentRequest.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace MosaicResidentInformationApi.V1.Boundary.Requests
+{
+    public class AddResidentRequest
+    {
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}

--- a/MosaicResidentInformationApi/V1/Gateways/IMosaicGateway.cs
+++ b/MosaicResidentInformationApi/V1/Gateways/IMosaicGateway.cs
@@ -7,6 +7,9 @@ namespace MosaicResidentInformationApi.V1.Gateways
     {
         List<ResidentInformation> GetAllResidents(int cursor, int limit, long? id, string firstname = null, string lastname = null,
             string dateOfBirth = null, string postcode = null, string address = null, string contextFlag = null);
+
         ResidentInformation GetEntityById(long id, string contextflag = null);
+
+        ResidentInformation InsertResident(string firstName, string lastName);
     }
 }

--- a/MosaicResidentInformationApi/V1/Gateways/MosaicGateway.cs
+++ b/MosaicResidentInformationApi/V1/Gateways/MosaicGateway.cs
@@ -67,6 +67,27 @@ namespace MosaicResidentInformationApi.V1.Gateways
 
             return person;
         }
+        public ResidentInformation InsertResident(string firstName, string lastName)
+        {
+            Person person = new Person()
+            {
+                FirstName = firstName,
+                LastName = lastName,
+                FullName = $"{firstName} {lastName}", // Cannot be null
+                Gender = "-", // Cannot be null
+                PersonIdLegacy = "-", // Cannot be null
+            };
+
+            _mosaicContext.Persons.Add(person);
+            _mosaicContext.SaveChanges();
+
+            return new ResidentInformation()
+            {
+                MosaicId = person.Id.ToString(),
+                FirstName = person.FirstName,
+                LastName = person.LastName,
+            };
+        }
 
         private List<long> PeopleIds(int cursor, int limit, long? id, string firstname, string lastname, string dateOfBirth, string contextflag)
         {

--- a/MosaicResidentInformationApi/V1/UseCase/AddResidentUseCase.cs
+++ b/MosaicResidentInformationApi/V1/UseCase/AddResidentUseCase.cs
@@ -1,0 +1,24 @@
+using MosaicResidentInformationApi.V1.Boundary.Requests;
+using MosaicResidentInformationApi.V1.Boundary.Responses;
+using MosaicResidentInformationApi.V1.Factories;
+using MosaicResidentInformationApi.V1.Gateways;
+using MosaicResidentInformationApi.V1.UseCase.Interfaces;
+
+namespace MosaicResidentInformationApi.V1.UseCase
+{
+    public class AddResidentUseCase : IAddResidentUseCase
+    {
+        private IMosaicGateway _mosaicGateway;
+        public AddResidentUseCase(IMosaicGateway mosaicGateway)
+        {
+            _mosaicGateway = mosaicGateway;
+        }
+
+        public ResidentInformation Execute(AddResidentRequest resident)
+        {
+            var residentInformation = _mosaicGateway.InsertResident(firstName: resident.FirstName, lastName: resident.LastName);
+
+            return residentInformation.ToResponse();
+        }
+    }
+}

--- a/MosaicResidentInformationApi/V1/UseCase/Interfaces/IAddResidentUseCase.cs
+++ b/MosaicResidentInformationApi/V1/UseCase/Interfaces/IAddResidentUseCase.cs
@@ -1,0 +1,10 @@
+using MosaicResidentInformationApi.V1.Boundary.Requests;
+using MosaicResidentInformationApi.V1.Boundary.Responses;
+
+namespace MosaicResidentInformationApi.V1.UseCase.Interfaces
+{
+    public interface IAddResidentUseCase
+    {
+        ResidentInformation Execute(AddResidentRequest addResident);
+    }
+}


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Before we add any recovered Mosaic data, we must move the Mosaic Platform API and its database to a more secure AWS account. However as the Mosaic Platform API is in use by the Social Care Case Viewer API and pointing to the same database, we need to achieve feature parity first.

### *What changes have we introduced*

This PR is the first smol step towards allowing a new resident be created in the Mosaic Platform API. It adds a new method to the `MosaicGateway#InsertResident` and a new use case called `AddResident`. For now, the only properties that are of concern are just first name and last name. The details of a resident like their address and phone numbers will be added once all the pieces are connected end to end i.e. we have an API endpoint which can create a resident with their first name and last name.

### *Follow up actions after merging PR*

1. Add new API endpoint for adding a resident
2. Handle errors/exceptions
3. Add the rest of the properties for a resident 

## Link to Trello ticket

https://trello.com/c/JzRGKcc5/38-add-create-person-endpoint-for-platform-api

