### PR TITLE
Update CircleCI config to run Terraform plan and apply for ProductionAPIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,25 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
+  terraform-init-then-plan:
+    description: "Initializes and applies terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+          name: get and init
+      - run:
+          name: apply
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform plan
   deploy-lambda:
     description: "Deploys API via Serverless"
     parameters:
@@ -138,6 +157,11 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "production"
+  terraform-init-and-plan-to-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:
@@ -155,14 +179,14 @@ jobs:
           stage: "production"
 
 workflows:
-  terraform-apply-production:
+  terraform-plan-production:
     jobs:
       - assume-role-production:
           context: api-assume-role-production-context
           filters:
             branches:
-              only: master
-      - terraform-init-and-apply-to-production:
+              only: update-terraform-in-circleci
+      - terraform-init-and-plan-to-production:
           requires:
             - assume-role-production
   check-and-deploy-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
             terraform init
           name: get and init
       - run:
-          name: apply
+          name: plan
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform plan
@@ -179,16 +179,23 @@ jobs:
           stage: "production"
 
 workflows:
-  terraform-plan-production:
+  terraform-plan-and-apply-production:
     jobs:
       - assume-role-production:
           context: api-assume-role-production-context
           filters:
             branches:
-              only: update-terraform-in-circleci
+              only: master
       - terraform-init-and-plan-to-production:
           requires:
             - assume-role-production
+      - permit-production-terraform:
+          type: approval
+          requires:
+            - terraform-init-and-plan-to-production
+      - terraform-init-and-apply-to-production:
+          requires:
+            - permit-production-terraform
   check-and-deploy-development:
     jobs:
       - check-code-formatting

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -56,7 +56,7 @@ module "postgres_db_production" {
   subnet_ids = data.aws_subnet_ids.production.ids
   db_engine = "postgres"
   db_engine_version = "11.1" //DMS does not work well with v12
-  db_instance_class = "db.t2.micro"
+  db_instance_class = "db.t3.micro"
   db_allocated_storage = 20
   maintenance_window ="sun:10:00-sun:10:30"
   db_username = "mosaicapi_admin"
@@ -100,7 +100,7 @@ data "aws_ssm_parameter" "mosaic_db_name_reporting" {
 }
 
  module "dms_setup_production" {
-   source = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_full_setup"
+   source = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_full_setup?ref=temp-mosaic-platform-api-changes"
    environment_name = "production" //used for resource tags
    project_name = "resident-information-apis" //used for resource tags
    //target db for dms endpoint
@@ -125,7 +125,7 @@ data "aws_ssm_parameter" "mosaic_db_name_reporting" {
    allocated_storage = 20 //in GB
    maintenance_window = "sun:07:00-sun:07:30"
    replication_instance_class = "dms.t2.small"
-   replication_instance_identifier = "production-dms-instance"
+   replication_instance_identifier = "temporary-mosaic-dms-instance"
    vpc_name = "vpc-production-apis"
    dms_instance_publicly_accessible = false
    //dms task set up

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -125,7 +125,7 @@ data "aws_ssm_parameter" "mosaic_db_name_reporting" {
    allocated_storage = 20 //in GB
    maintenance_window = "sun:07:00-sun:07:30"
    replication_instance_class = "dms.t2.small"
-   replication_instance_identifier = "temporary-mosaic-dms-instance"
+   replication_instance_identifier = "production-dms-instance"
    vpc_name = "vpc-production-apis"
    dms_instance_publicly_accessible = false
    //dms task set up


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-447

## Describe this PR

### *What is the problem we're trying to solve*

We want to remove the RDS and DMS resources in ProductionAPIs for this API as they're no longer used. In #84, we tried to get the Terraform in sync but it failed because of the version of the DMS instance was not in sync as well as other issues (see [CircleCI pipeline output](https://app.circleci.com/pipelines/github/LBHackney-IT/mosaic-resident-information-api/387/workflows/8d75a20c-208c-404e-bd96-f783dac124d2/jobs/1517)).

### *What changes have we introduced*

This PR updates our temporary workflow to do a Terraform plan and apply and uses a temporary version (or branch) of the [Hackney's AWS DMS Terraform module](https://github.com/LBHackney-IT/aws-dms-terraform/tree/temp-mosaic-platform-api-changes) which makes the DMS instance in sync with what's set up in AWS.

### *Follow up actions after merging PR*

1. Run the pipeline
2. Assuming Terraform runs successfully, remove the resources in the `terraform/production` folder
3. Run the pipeline
4. Assuming Terraform removes the resources, remove temporary workflow
5. Remove temporary branch in AWS DMS Terraform
6. Remove completely the `terraform/production` folder