### PR TITLE
Remove temporary CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,25 +57,6 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
-  terraform-init-then-plan:
-    description: "Initializes and applies terraform configuration"
-    parameters:
-      environment:
-        type: string
-    steps:
-      - *attach_workspace
-      - checkout
-      - run:
-          command: |
-            cd ./terraform/<<parameters.environment>>/
-            terraform get -update=true
-            terraform init
-          name: get and init
-      - run:
-          name: plan
-          command: |
-            cd ./terraform/<<parameters.environment>>/
-            terraform plan
   deploy-lambda:
     description: "Deploys API via Serverless"
     parameters:
@@ -157,11 +138,6 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "production"
-  terraform-init-and-plan-to-production:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-plan:
-          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:
@@ -179,23 +155,6 @@ jobs:
           stage: "production"
 
 workflows:
-  terraform-plan-and-apply-production:
-    jobs:
-      - assume-role-production:
-          context: api-assume-role-production-context
-          filters:
-            branches:
-              only: master
-      - terraform-init-and-plan-to-production:
-          requires:
-            - assume-role-production
-      - permit-production-terraform:
-          type: approval
-          requires:
-            - terraform-init-and-plan-to-production
-      - terraform-init-and-apply-to-production:
-          requires:
-            - permit-production-terraform
   check-and-deploy-development:
     jobs:
       - check-code-formatting


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-447

## Describe this PR

### *What is the problem we're trying to solve*

We want to remove the RDS and DMS resources in ProductionAPIs for this API as they're no longer used.

In #84, we tried to get the Terraform in sync but it failed because of the version of the DMS instance was not in sync as well as other issues (see [CircleCI pipeline output](https://app.circleci.com/pipelines/github/LBHackney-IT/mosaic-resident-information-api/387/workflows/8d75a20c-208c-404e-bd96-f783dac124d2/jobs/1517)).

In #85, we managed to get Terraform in sync however we're unable to remove the resources without removing the DMS instance used at the same time. We don't want to remove the DMS instance as it's currently being used by the Addresses API. As a result, our attempts to use Terraform to remove the resources have been unsuccessfully and we'll need to remove them manually via the console to avoid removing this DMS instance.

### *What changes have we introduced*

This PR cleans up the CircleCI config to remove the temporary workflow we added to get Terraform in sync.

### *Follow up actions after merging PR*

1. Remove the RDS and DMS related resources but not the DMS instance via the console.
2. Remove the `terraform/production` folder and from CircleCI config.
