### PR TITLE
Remove deployment to ProductionAPIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,21 @@ references:
       at: *workspace_root
 
 commands:
+  assume-role-and-persist-workspace:
+    description: "Assumes deployment role and persists credentials across jobs"
+    parameters:
+      aws-account:
+        type: string
+    steps:
+      - checkout
+      - aws_assume_role/assume_role:
+          account: <<parameters.aws-account>>
+          profile_name: default
+          role: "LBH_Circle_CI_Deployment_Role"
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
   assume-role-and-persist-workspace-mosaic-production:
     description: "Assumes deployment role and persists credentials across jobs for Mosaic-Production"
     parameters:
@@ -108,11 +123,21 @@ jobs:
       - run:
           name: Run tests
           command: docker-compose run mosaic-resident-information-api-test
+  assume-role-staging:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_STAGING
   assume-role-mosaic-production:
     executor: docker-python
     steps:
       - assume-role-and-persist-workspace-mosaic-production:
           aws-account: $AWS_ACCOUNT_PRODUCTION
+  deploy-to-staging:
+    executor: docker-dotnet
+    steps:
+      - deploy-lambda:
+          stage: "staging"
   deploy-to-mosaic-production:
     executor: docker-dotnet
     steps:
@@ -124,7 +149,7 @@ workflows:
     jobs:
       - check-code-formatting
       - build-and-test
-  check-and-deploy-mosaic-production:
+  check-and-deploy-staging-and-mosaic-production:
       jobs:
       - build-and-test:
           filters:
@@ -146,20 +171,20 @@ workflows:
       - permit-mosaic-production-release:
           type: approval
           requires:
-            - build-and-test
+            - deploy-to-staging
           filters:
             branches:
-              only: deploy-to-mosaic-prod
+              only: master
       - assume-role-mosaic-production:
           context: api-assume-role-social-care-production-context
           requires:
             - permit-mosaic-production-release
           filters:
             branches:
-              only: deploy-to-mosaic-prod
+              only: master
       - deploy-to-mosaic-production:
           requires:
             - assume-role-mosaic-production
           filters:
             branches:
-              only: deploy-to-mosaic-prod
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ references:
       at: *workspace_root
 
 commands:
-  assume-role-and-persist-workspace:
-    description: "Assumes deployment role and persists credentials across jobs"
+  assume-role-and-persist-workspace-mosaic-production:
+    description: "Assumes deployment role and persists credentials across jobs for Mosaic-Production"
     parameters:
       aws-account:
         type: string
@@ -33,7 +33,7 @@ commands:
       - aws_assume_role/assume_role:
           account: <<parameters.aws-account>>
           profile_name: default
-          role: "LBH_Circle_CI_Deployment_Role"
+          role: "circleci-assume-role"
       - persist_to_workspace:
           root: *workspace_root
           paths:
@@ -108,78 +108,24 @@ jobs:
       - run:
           name: Run tests
           command: docker-compose run mosaic-resident-information-api-test
-  assume-role-development:
+  assume-role-mosaic-production:
     executor: docker-python
     steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_DEVELOPMENT
-  assume-role-staging:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_STAGING
-  assume-role-production:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
+      - assume-role-and-persist-workspace-mosaic-production:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  terraform-init-and-apply-to-development:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-apply:
-          environment: "development"
-  terraform-init-and-apply-to-staging:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-apply:
-          environment: "staging"
-  terraform-init-and-apply-to-production:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-apply:
-          environment: "production"
-  deploy-to-development:
+  deploy-to-mosaic-production:
     executor: docker-dotnet
     steps:
       - deploy-lambda:
-          stage: "development"
-  deploy-to-staging:
-    executor: docker-dotnet
-    steps:
-      - deploy-lambda:
-          stage: "staging"
-  deploy-to-production:
-    executor: docker-dotnet
-    steps:
-      - deploy-lambda:
-          stage: "production"
+          stage: "mosaic-prod"
 
 workflows:
   check-and-deploy-development:
     jobs:
       - check-code-formatting
       - build-and-test
-      - assume-role-development:
-          context: api-assume-role-development-context
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              only: development
-      # - terraform-init-and-apply-to-development:
-          # requires:
-            # - assume-role-development
-          # filters:
-            # branches:
-              # only: development
-      - deploy-to-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: development
-  check-and-deploy-staging-and-production:
-    jobs:
+  check-and-deploy-mosaic-production:
+      jobs:
       - build-and-test:
           filters:
             branches:
@@ -197,23 +143,23 @@ workflows:
           filters:
             branches:
               only: master
-      - permit-production-release:
+      - permit-mosaic-production-release:
           type: approval
           requires:
-            - deploy-to-staging
+            - build-and-test
           filters:
             branches:
-              only: master
-      - assume-role-production:
-          context: api-assume-role-production-context
+              only: deploy-to-mosaic-prod
+      - assume-role-mosaic-production:
+          context: api-assume-role-social-care-production-context
           requires:
-            - permit-production-release
+            - permit-mosaic-production-release
           filters:
             branches:
-              only: master
-      - deploy-to-production:
+              only: deploy-to-mosaic-prod
+      - deploy-to-mosaic-production:
           requires:
-            - assume-role-production
+            - assume-role-mosaic-production
           filters:
             branches:
-              only: master
+              only: deploy-to-mosaic-prod

--- a/MosaicResidentInformationApi/serverless.yml
+++ b/MosaicResidentInformationApi/serverless.yml
@@ -9,6 +9,14 @@ provider:
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
+  apiKeys:
+    - secureAccess:
+      - api-key-${self:service}-${self:provider.stage}
+  usagePlan:
+    - secureAccess:
+        throttle:
+          burstLimit: 200
+          rateLimit: 100
 
 package:
   artifact: ./bin/release/netcoreapp3.1/mosaic-resident-information-api.zip
@@ -24,9 +32,6 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
-          authorizer:
-            arn: ${ssm:/platform-apis-lambda-authorizer-arn}
-            type: request
           private: false
     provisionedConcurrency: 10
 resources:

--- a/MosaicResidentInformationApi/serverless.yml
+++ b/MosaicResidentInformationApi/serverless.yml
@@ -88,21 +88,9 @@ resources:
                   Resource: "*"
 custom:
   vpc:
-    development:
+    mosaic-prod:
       securityGroupIds:
-        - sg-0615f1e12aacd43fb
+        - sg-0d92164e9f5d53800
       subnetIds:
-        - subnet-0deabb5d8fb9c3446
-        - subnet-000b89c249f12a8ad
-    staging:
-      securityGroupIds:
-        - sg-03c4502c86db0e086
-      subnetIds:
-        - subnet-06d3de1bd9181b0d7
-        - subnet-0ed7d7713d1127656
-    production:
-      securityGroupIds:
-        - sg-0e2398788c29e09ca
-      subnetIds:
-        - subnet-01d3657f97a243261
-        - subnet-0b7b8fea07efabf34
+        - subnet-0665104ee973a21be
+        - subnet-005b74d8082f68a84

--- a/MosaicResidentInformationApi/serverless.yml
+++ b/MosaicResidentInformationApi/serverless.yml
@@ -88,6 +88,12 @@ resources:
                   Resource: "*"
 custom:
   vpc:
+    staging:
+      securityGroupIds:
+        - sg-03c4502c86db0e086
+      subnetIds:
+        - subnet-06d3de1bd9181b0d7
+        - subnet-0ed7d7713d1127656
     mosaic-prod:
       securityGroupIds:
         - sg-0d92164e9f5d53800

--- a/MosaicResidentInformationApi/serverless.yml
+++ b/MosaicResidentInformationApi/serverless.yml
@@ -27,7 +27,7 @@ functions:
     handler: MosaicResidentInformationApi::MosaicResidentInformationApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
     environment:
-      CONNECTION_STRING: Host=${ssm:/mosaic-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/mosaic-api/${self:provider.stage}/postgres-port};Database=${ssm:/mosaic-api/${self:provider.stage}/postgres-database};Username=${ssm:/mosaic-api/${self:provider.stage}/postgres-username};Password=${ssm:/mosaic-api/${self:provider.stage}/postgres-password};MaxPoolSize=${ssm:/mosaic-api/${self:provider.stage}/postgres-max-pool-size};
+      CONNECTION_STRING: Host=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-port};Database=social_care;Username=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-username};Password=${ssm:/social-care-case-viewer-api/${self:provider.stage}/postgres-password~true};MaxPoolSize=100;
     events:
       - http:
           path: /{proxy+}

--- a/README.md
+++ b/README.md
@@ -53,12 +53,7 @@ Then we have an automated six step deployment process, which runs in CircleCI.
 5. We manually confirm a production deployment in the CircleCI workflow once we're happy with our changes in staging.
 6. The application is deployed to production.
 
-Our staging and production environments are hosted by AWS. For production, we deploy to two AWS accounts: ProductionAPIs and Mosaic-Production. This is due to an account migration for the [Social Care Case Viewer API](https://github.com/LBHackney-IT/social-care-case-viewer-api) which means:
-
-- Merges into `master`, deploys to StagingAPIs and then ProductionAPIs (see [CircleCI config](https://github.com/LBHackney-IT/mosaic-resident-information-api/blob/230c6dfaec39427c995f74b81dc22479ad2840d0/.circleci/config.yml#L180))
-- Merges into `deploy-to-mosaic-prod`, deploys to Mosaic-Production (see [CircleCI config](https://github.com/LBHackney-IT/mosaic-resident-information-api/blob/12b719be9bc39916965473e987c0c6c446204dd8/.circleci/config.yml#L126))
-
-The only difference between the two is that ProductionAPIs uses the Lambda authoriser for auth and Mosaic-Production uses API keys.
+Our staging and production environments are hosted by AWS. For staging, we deploy to StagingAPIs and for production, we deploy to the Mosaic-Production AWS account. Merges into `master` deploy to staging and production, see [CircleCI config](./.circleci/config.yml).
 
 ## Testing
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-447

## Describe this PR

### *What is the problem we're trying to solve*

We no longer deploy to ProductionAPIs for our production environment as it now lives in Mosaic-Production AWS account instead and have removed all the resources from the AWS account.

At one point, we'd set up deployment from `master` and `deploy-to-mosaic-prod` so we could continue deployment to both AWS accounts but now we no longer need to do this so we want to make `master` the only deployment branch we have and get rid of `deploy-to-mosaic-prod`.

### *What changes have we introduced*

This PR will update `master` to deploy to StagingAPIs and then Mosaic-Production as well as updates the README to reflect this update.