### PR TITLE
Remove provisioned concurrency for Lambda

### DIFF
--- a/MosaicResidentInformationApi/serverless.yml
+++ b/MosaicResidentInformationApi/serverless.yml
@@ -33,7 +33,6 @@ functions:
           path: /{proxy+}
           method: ANY
           private: false
-    provisionedConcurrency: 10
 resources:
   Resources:
     lambdaExecutionRole:


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Originally, provisioned concurrency was added to tackle the initial performance issues. Looking at the latest stats, the utilisation of provisioned concurrency is really low so there’s no need for it.

### *What changes have we introduced*

This PR removes the `provisionedConcurrency` attribute for the Lambda.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-533