### PR TITLE
increase no output timeout in preparation for prod resources deletion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,21 +23,6 @@ references:
       at: *workspace_root
 
 commands:
-  assume-role-and-persist-workspace:
-    description: "Assumes deployment role and persists credentials across jobs"
-    parameters:
-      aws-account:
-        type: string
-    steps:
-      - checkout
-      - aws_assume_role/assume_role:
-          account: <<parameters.aws-account>>
-          profile_name: default
-          role: "LBH_Circle_CI_Deployment_Role"
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .aws
   assume-role-and-persist-workspace-mosaic-production:
     description: "Assumes deployment role and persists credentials across jobs for Mosaic-Production"
     parameters:
@@ -72,26 +57,17 @@ commands:
           command: npm i -g serverless
       - run:
           name: Remove resources
+          no_output_timeout: 40m
           command: |
             cd ./MosaicResidentInformationApi/
             sls remove --stage <<parameters.stage>>
 
 jobs:
-  assume-role-staging:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_STAGING
   assume-role-mosaic-production:
     executor: docker-python
     steps:
       - assume-role-and-persist-workspace-mosaic-production:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  remove-staging-resources:
-    executor: docker-dotnet
-    steps:
-      - remove-resources:
-          stage: "staging"
   remove-mosaic-production-resources:
     executor: docker-dotnet
     steps:
@@ -99,30 +75,10 @@ jobs:
           stage: "mosaic-prod"
 
 workflows:
-  remove-resources-from-staging-and-mosaic-production:
+  remove-resources-from-mosaic-production:
     jobs:
-      - permit-staging-resources-removal:
-          type: approval
-          filters:
-            branches:
-              only: master
-      - assume-role-staging:
-          requires:
-            - permit-staging-resources-removal
-          context: api-assume-role-staging-context
-          filters:
-            branches:
-              only: master
-      - remove-staging-resources:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
       - permit-mosaic-production-resources-removal:
           type: approval
-          requires:
-            - remove-staging-resources
           filters:
             branches:
               only: master


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

When `sls remove` was run against staging the workflow timed out because CloudFormation stack deletion took quite a while. The default no output timeout is 10mins which is not enough for this operation.

### *What changes have we introduced*

- Increase the `no_output_timeout` to 40mins which should be enough to cover the stack deletion time
- The workflow for staging was re-run and all staging resources have now been deleted. This PR also removes the staging related jobs from the workflow since there's no reason to run them again.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
