### PR TITLE
Add feature workflow with Terraform preview steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,20 @@ jobs:
           environment: "staging"
 
 workflows:
+  feature:
+    jobs:
+      - assume-role-development:
+          context: api-assume-role-development-context
+          filters:
+            branches:
+              ignore: master
+      - preview-terraform-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              ignore: master
+
   remove-resources-from-mosaic-production:
     jobs:
       - permit-mosaic-production-resources-removal:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,17 @@ workflows:
           filters:
             branches:
               ignore: master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          filters:
+            branches:
+              ignore: master
+      - preview-terraform-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              ignore: master
 
   remove-resources-from-mosaic-production:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
-    assume-role-and-persist-workspace:
+  assume-role-and-persist-workspace:
     description: "Assumes deployment role and persists credentials across jobs"
     parameters:
       aws-account:
@@ -95,6 +95,21 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  terraform-preview:
+    description: "Initializes and applies terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: preview TF
 
 jobs:
   assume-role-mosaic-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,21 @@ jobs:
     steps:
       - remove-resources:
           stage: "mosaic-prod"
+  assume-role-development:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_DEVELOPMENT
+  preview-terraform-development:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "development"
+  terraform-init-and-apply-to-development:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-apply:
+          environment: "development"
 
 workflows:
   remove-resources-from-mosaic-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,25 @@ commands:
           command: |
             cd ./MosaicResidentInformationApi/
             sls remove --stage <<parameters.stage>>
+  terraform-init-then-apply:
+    description: "Initializes and applies terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+          name: get and init
+      - run:
+          name: apply
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform apply -auto-approve
 
 jobs:
   assume-role-mosaic-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,21 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
+    assume-role-and-persist-workspace:
+    description: "Assumes deployment role and persists credentials across jobs"
+    parameters:
+      aws-account:
+        type: string
+    steps:
+      - checkout
+      - aws_assume_role/assume_role:
+          account: <<parameters.aws-account>>
+          profile_name: default
+          role: "LBH_Circle_CI_Deployment_Role"
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
 
 jobs:
   assume-role-mosaic-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,21 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "development"
+  assume-role-staging:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_STAGING
+  preview-terraform-staging:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "staging"
+  terraform-init-and-apply-to-staging:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-apply:
+          environment: "staging"
 
 workflows:
   remove-resources-from-mosaic-production:


### PR DESCRIPTION
# What:
 - Added a feature workflow.

# Why:
 - To preview `development` and `staging` terraform changes.
 - To preview whether the Terraform portion of the pipeline is incapable of running due to staleness.

# Notes:
 - Pipeline fails because the VPC has been renamed. That is fine for the purposes of this PR. The issue will get addressed later on.