### PR TITLE
Retire `development` & `staging` Terraform resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,23 @@ workflows:
 
   remove-resources-from-mosaic-production:
     jobs:
+      - permit-mosaic-development-resources-removal:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - assume-role-development:
+          context: api-assume-role-development-context
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              only: master
+
       - permit-mosaic-production-resources-removal:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,25 @@ workflows:
           filters:
             branches:
               only: master
-      
+
+      - permit-mosaic-staging-resources-removal:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          requires:
+            - permit-mosaic-staging-resources-removal
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: master
 
       - permit-mosaic-production-resources-removal:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,9 +193,15 @@ workflows:
           filters:
             branches:
               only: master
-      - terraform-init-and-apply-to-development:
+      - preview-terraform-development:
           requires:
             - assume-role-development
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-development:
+          requires:
+            - preview-terraform-development
           filters:
             branches:
               only: master
@@ -212,9 +218,15 @@ workflows:
           filters:
             branches:
               only: master
-      - terraform-init-and-apply-to-staging:
+      - preview-terraform-staging:
           requires:
             - assume-role-staging
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-staging:
+          requires:
+            - preview-terraform-staging
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,8 @@ workflows:
               only: master
       - assume-role-development:
           context: api-assume-role-development-context
+          requires:
+            - permit-mosaic-development-resources-removal
           filters:
             branches:
               only: master
@@ -197,6 +199,7 @@ workflows:
           filters:
             branches:
               only: master
+      
 
       - permit-mosaic-production-resources-removal:
           type: approval

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -11,19 +11,6 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-locals {
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
-
-data "aws_iam_role" "ec2_container_service_role" {
-  name = "ecsServiceRole"
-}
-
-data "aws_iam_role" "ecs_task_execution_role" {
-  name = "ecsTaskExecutionRole"
-}
 
 terraform {
   backend "s3" {

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -47,24 +47,3 @@ data "aws_subnet_ids" "development_private_subnets" {
     values = ["private"]
   }
 }
-//database to be used for development purposes, not for DMS
-module "postgres_db_development" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "development"
-  vpc_id = data.aws_vpc.development_vpc.id
-  db_engine = "postgres"
-  db_engine_version = "11.1"
-  db_identifier = "mosaic-dev-db"
-  db_instance_class = "db.t2.micro"
-  db_name = "mosaic_dev"
-  db_port  = 5002
-  db_username = "${local.parameter_store}/mosaic-api/development/postgres-username"
-  db_password = "${local.parameter_store}/mosaic-api/development/postgres-password"
-  subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
-}

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -33,17 +33,3 @@ terraform {
     key     = "services/mosaic-resident-information-api/state"
   }
 }
-
-/*    POSTGRES SET UP    */
-data "aws_vpc" "development_vpc" {
-  tags = {
-    Name = "vpc-development-apis-development"
-  }
-}
-data "aws_subnet_ids" "development_private_subnets" {
-  vpc_id = data.aws_vpc.development_vpc.id
-  filter {
-    name   = "tag:Type"
-    values = ["private"]
-  }
-}


### PR DESCRIPTION
# What:
 - Added Terraform apply steps for `development` and `staging` environments.
 - Removed `development` Terraform.

# Why:
 - We're retiring `development` resources and database due to not having been used for ~15months.
 - Database snapshot was taken under the name of: `mosaic-mirror-db-development-manual-snapshot`.

# Screenshots:
| Development database hasn't been in use for 15 months | No active DMS tasks running |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/167778ea-8fb4-4dda-8839-48b699253544) | ![image](https://github.com/user-attachments/assets/dea4fa29-465d-481b-8820-afbca00797f2) |