### PR TITLE
Retire `StagingAPIs` environment terraform resources.

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -54,27 +54,7 @@ data "aws_subnet_ids" "staging" {
  data "aws_ssm_parameter" "mosaic_postgres_username" {
    name = "/mosaic-api/staging/postgres-username"
  }
- 
-module "postgres_db_staging" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "staging"
-  vpc_id = data.aws_vpc.staging_vpc.id
-  db_identifier = "mosaic-mirror"
-  db_name = "mosaic_mirror"
-  db_port  = 5002
-  subnet_ids = data.aws_subnet_ids.staging.ids
-  db_engine = "postgres"
-  db_engine_version = "11.1" //DMS does not work well with v12
-  db_instance_class = "db.t2.micro"
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  db_username = data.aws_ssm_parameter.mosaic_postgres_username.value
-  db_password = data.aws_ssm_parameter.mosaic_postgres_db_password.value
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
-}
+
 
 /*    DMS SET UP    */
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -104,23 +104,6 @@ data "aws_ssm_parameter" "mosaic_test_hostname" {
    }
  }
 
- resource "aws_iam_role" "dms-access-for-endpoint" {
-   assume_role_policy = "${data.aws_iam_policy_document.dms_assume_role.json}"
-   name               = "dms-access-for-endpoint"
- }
- resource "aws_iam_role_policy_attachment" "dms-access-for-endpoint-AmazonDMSRedshiftS3Role" {
-   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role"
-   role       = "${aws_iam_role.dms-access-for-endpoint.name}"
- }
- resource "aws_iam_role" "dms-vpc-role" {
-   assume_role_policy = "${data.aws_iam_policy_document.dms_assume_role.json}"
-   name               = "dms-vpc-role"
- }
- resource "aws_iam_role_policy_attachment" "dms-vpc-role-AmazonDMSVPCManagementRole" {
-   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
-   role       = "${aws_iam_role.dms-vpc-role.name}"
- }
-
 # /*   ADD SECURITY RULE TO POSTGRES DB TO ALLOW DMS TRAFFIC   */
 data "aws_security_group" "mosaic_postgres_sg" {
    filter {


### PR DESCRIPTION
# What:
 - Remove the `mosaic-mirror-db-staging` AWS RDS postgres database instance on `StagingAPIs` account.
 - Remove the DMS setup related to this database.

# Why:
 - The database hasn't been connected to in over 15 months and was marked for deletion.
 - The DMS task is also stale and hasn't been touched since 2021.

# Notes:
 - The database snapshot was taken under the name of: `mosaic-mirror-db-staging-manual-snapshot`.

# Screenshots:

| Staging database hasn't been used in 15 months | DMS tasks haven't been run in years |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/dcbd49b0-7348-4749-8f53-d17e9336798c) | ![image](https://github.com/user-attachments/assets/6123f7e5-32a0-4c2d-9ad9-d530ac39dccb) |