### PR TITLE
Clear abandoned AWS DMS replication tasks on `StagingAPIs` account.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
+  aws-cli: circleci/aws-cli@1.0.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:
@@ -110,6 +110,19 @@ commands:
             terraform init
             terraform plan
           name: preview TF
+  remove-abandoned-staging-tasks:
+    description: "Remove abandoned replication tasks that were stopped in 2021"
+    steps:
+      - aws-cli/install
+      - run:
+          name: remove abandoned tasks
+          no_output_timeout: 45m
+          command: |
+            aws dms describe-replication-tasks --query 'ReplicationTasks[].[ReplicationTaskIdentifier,ReplicationTaskArn]' --output text |
+            while IFS='\t' read -r name arn; do
+              echo "This task is named: #$name#, and its arn is: #$arn#."
+            done
+
 
 jobs:
   assume-role-mosaic-production:
@@ -139,9 +152,17 @@ jobs:
       - terraform-init-then-apply:
           environment: "staging"
 
+  clear-dms-tasks:
+    executor: aws-cli/default
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_STAGING
+      - remove-abandoned-staging-tasks
+
 workflows:
   feature:
     jobs:
+      - clear-dms-tasks
       - assume-role-staging:
           context: api-assume-role-staging-context
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ commands:
           command: |
             aws dms describe-replication-tasks --query 'ReplicationTasks[].[ReplicationTaskIdentifier,ReplicationTaskArn]' --output text |
             while IFS=$'\t' read -r name arn; do
-              echo "This task is named: #$name#, and its arn is: #$arn#."
+              echo "Removing task named: #$name# with arn: #$arn#."
             done
 
 
@@ -166,12 +166,6 @@ workflows:
           filters:
             branches:
               ignore: master
-      - clear-dms-tasks:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              ignore: master
       - preview-terraform-staging:
           requires:
             - assume-role-staging
@@ -193,9 +187,15 @@ workflows:
           filters:
             branches:
               only: master
-      - preview-terraform-staging:
+      - clear-dms-tasks:
           requires:
             - assume-role-staging
+          filters:
+            branches:
+              only: master
+      - preview-terraform-staging:
+          requires:
+            - clear-dms-tasks
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,8 @@ workflows:
             branches:
               ignore: master
       - clear-dms-tasks:
-        context: api-assume-role-staging-context
+          requires:
+            - assume-role-staging
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,8 @@ commands:
             aws dms describe-replication-tasks --query 'ReplicationTasks[].[ReplicationTaskIdentifier,ReplicationTaskArn]' --output text |
             while IFS=$'\t' read -r name arn; do
               echo "Removing task named: #$name# with arn: #$arn#."
+              aws dms delete-replication-task --replication-task-arn "$arn"
+              echo -e "Task removed.\n"
             done
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ commands:
           no_output_timeout: 45m
           command: |
             aws dms describe-replication-tasks --query 'ReplicationTasks[].[ReplicationTaskIdentifier,ReplicationTaskArn]' --output text |
-            while IFS='\t' read -r name arn; do
+            while IFS=$'\t' read -r name arn; do
               echo "This task is named: #$name#, and its arn is: #$arn#."
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@1.0.0
+  aws-cli: circleci/aws-cli@5.1.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:
@@ -113,6 +113,7 @@ commands:
   remove-abandoned-staging-tasks:
     description: "Remove abandoned replication tasks that were stopped in 2021"
     steps:
+      - *attach_workspace
       - aws-cli/install
       - run:
           name: remove abandoned tasks
@@ -155,16 +156,18 @@ jobs:
   clear-dms-tasks:
     executor: aws-cli/default
     steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_STAGING
       - remove-abandoned-staging-tasks
 
 workflows:
   feature:
     jobs:
-      - clear-dms-tasks
       - assume-role-staging:
           context: api-assume-role-staging-context
+          filters:
+            branches:
+              ignore: master
+      - clear-dms-tasks:
+        context: api-assume-role-staging-context
           filters:
             branches:
               ignore: master


### PR DESCRIPTION
# What:
 - Remove AWS DMS replication tasks on `StagingAPIs` account.

# Why:
 - The only replication tasks on this account are for the `dms_setup_staging` setup whose removal was discussed on PR #97 .
 - These tasks are blocking the removal of remaining `StagingAPIs` terraform resources due (chances are) them having been created manually.

# Notes:
 - This PR will attempt at removing these tasks, however, if they depend on any further resources, another PR will be needed to address that. There's no way test for these dependencies without running the delete workflow.
 - You'll notice that the full list of DMS tasks matches the list of tasks under the to-be-remove DMS replication instance shown in the screenshots of the PR #97 .

# Screenshots:

| StagingAPIs terraform resource removal fails | The only tasks left are related to to-be-removed DMS setup |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/580bfc43-7067-4d35-bbfb-7fa4c52b44c8) | ![image](https://github.com/user-attachments/assets/c0ed9ab6-0dbe-4e92-9f70-da1953e2e5e4) |
